### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0
         with:
           fetch-depth: 0
           # submodules: true
@@ -40,7 +40,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.267.0
         with:
           ruby-version: 3.2
           bundler-cache: true
@@ -57,7 +57,7 @@ jobs:
             \-\-ignore-urls "/^http:\/\/127.0.0.1/,/^http:\/\/0.0.0.0/,/^http:\/\/localhost/"
 
       - name: Upload site artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4.0.0
         with:
           path: "_site${{ steps.pages.outputs.base_path }}"
 
@@ -70,4 +70,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v4.0.5

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5.0.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[ruby/setup-ruby](https://github.com/ruby/setup-ruby)** published a new release **[v1.267.0](https://github.com/ruby/setup-ruby/releases/tag/v1.267.0)** on 2025-10-27T11:32:57Z
* **[actions/deploy-pages](https://github.com/actions/deploy-pages)** published a new release **[v4.0.5](https://github.com/actions/deploy-pages/releases/tag/v4.0.5)** on 2024-03-18T15:43:13Z
* **[actions/upload-pages-artifact](https://github.com/actions/upload-pages-artifact)** published a new release **[v4.0.0](https://github.com/actions/upload-pages-artifact/releases/tag/v4.0.0)** on 2025-08-14T19:21:06Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v5.0.0](https://github.com/actions/checkout/releases/tag/v5.0.0)** on 2025-08-11T12:39:13Z
