### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/configure-pages@v6.0.0
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.306.0
+        uses: ruby/setup-ruby@v1.310.0
         with:
           ruby-version: 3.2
           bundler-cache: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[ruby/setup-ruby](https://github.com/ruby/setup-ruby)** published a new release **[v1.310.0](https://github.com/ruby/setup-ruby/releases/tag/v1.310.0)** on 2026-05-20T20:08:29Z
