### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
           # submodules: true
@@ -40,7 +40,7 @@ jobs:
         uses: actions/configure-pages@v6.0.0
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.306.0
+        uses: ruby/setup-ruby@v1.314.0
         with:
           ruby-version: 3.2
           bundler-cache: true

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v7.0.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[ruby/setup-ruby](https://github.com/ruby/setup-ruby)** published a new release **[v1.314.0](https://github.com/ruby/setup-ruby/releases/tag/v1.314.0)** on 2026-06-20T13:41:33Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v7.0.0](https://github.com/actions/checkout/releases/tag/v7.0.0)** on 2026-06-18T13:53:05Z
